### PR TITLE
Fixed Exclamation Visibility and Door Interaction Fix

### DIFF
--- a/levels/inside_perimeter/events.js
+++ b/levels/inside_perimeter/events.js
@@ -107,6 +107,13 @@ module.exports = async function (event, world) {
   const openDoor = (group) => {
     world.forEachEntities(group, (door) => {
       door.state.fsm.action("open");
+      // prevents door from being marked as "inRangeObject" for the Player and
+      // stops the exclamation point from showing up
+      door.interactable = false;
+      // prevents the player from casting spells on the door, which would cause
+      // an animation to play as though the player was opening the door, even though it was
+      // already open
+      door.spellable = false;
     });
   };
 

--- a/levels/inside_perimeter/events.js
+++ b/levels/inside_perimeter/events.js
@@ -270,6 +270,8 @@ module.exports = async function (event, world) {
     }
 
     openDoor("scroll_room_door");
+    // Forces the player's exclamation point to become hidden after opening the door
+    event.target.level.player.inRangeObject = null;
 
     // Stop using tool after a second
     world.wait(1000).then(() => {


### PR DESCRIPTION
-Made it so the door has it's "interactable" property set to "false" upon opening to prevent the exclamation point from showing up and the door being set to the player's "inRangeObject" 
-Made it so the door has it's "spellable" property set to "false" upon opening to prevent the player from attempting to open the door and having an animation play as though they were unlocking it

For issue #14