### PR TITLE
Fix Player Exclamation Point Visibility For Catacombs Doorway After Opening Door

### DIFF
--- a/levels/inside_perimeter/events.js
+++ b/levels/inside_perimeter/events.js
@@ -65,6 +65,11 @@ const LEVEL_STATE = {
                 return worldState.insideCatacombs.hasKey;
               },
             },
+            successActions: {
+              hasKey({ event }) {
+                event.target.setInteractable(false);
+              },
+            },
             failureActions: {
               hasKey({ world }) {
                 world.showNotification(
@@ -245,7 +250,7 @@ module.exports = async function (event, world) {
     // current content. They'll learn their house later.
     // TODO: Update this notification on future release version.
     world.showNotification(
-      'I got my pledge scroll! I should head to the Main Hall to choose my house now!'
+      "I got my pledge scroll! I should head to the Main Hall to choose my house now!"
     );
     world.updateQuestStatus(
       world.__internals.level.levelName,


### PR DESCRIPTION
-Added "successAction" to catacombs door which sets the object's "interactable" state to false after the player opens the door

This fix relies on the changes to the [Player Class](https://github.com/twilio/twilioquest/pull/915) and [TiledObjects](https://github.com/twilio/twilioquest/pull/914) in the [TwilioQuest repo](https://github.com/twilio/twilioquest)

For issue #14