### PR TITLE
Release prep fixes and updates

### DIFF
--- a/levels/inside_perimeter/events.js
+++ b/levels/inside_perimeter/events.js
@@ -24,6 +24,16 @@ const LEVEL_STATE = {
         spell: {
           disappear: {
             requirements: {
+              disableInteraction({ event, world }) {
+                world.forEachEntities(
+                  ({ instance }) => instance.group === event.target.group,
+                  (bramble) => {
+                    bramble.setInteractable(false);
+                  }
+                );
+
+                return true;
+              },
               hasWand({ worldState }) {
                 return worldState.insidePerimeter.hasWand;
               },
@@ -42,6 +52,14 @@ const LEVEL_STATE = {
               hasDisappearSpell({ world }) {
                 world.showNotification(
                   "I think I need to learn a spell later to do anything here!"
+                );
+              },
+              disableInteraction({ event, world }) {
+                world.forEachEntities(
+                  ({ instance }) => instance.group === event.target.group,
+                  (bramble) => {
+                    bramble.setInteractable(true);
+                  }
                 );
               },
             },

--- a/levels/inside_perimeter/events.js
+++ b/levels/inside_perimeter/events.js
@@ -185,6 +185,9 @@ module.exports = async function (event, world) {
     if (worldState.insideCatacombs.keySpellsObtained.length == 4) {
       world.grantItems(["magic_key"]);
       unlockObject("magic_key");
+      world.forEachEntities("magic_key", (magicKey) => {
+        magicKey.setInteractable(true);
+      });
     }
   };
 
@@ -213,6 +216,10 @@ module.exports = async function (event, world) {
   };
 
   const addMagicKey = (event) => {
+    if (!event.target.interactable) {
+      return;
+    }
+
     worldState.insideCatacombs.hasKey = true;
     if (!worldState.spellsEarned.includes("unlock"))
       worldState.spellsEarned.push("unlock");
@@ -299,6 +306,12 @@ module.exports = async function (event, world) {
    * Handles returning level to last object state
    */
   if (event.name === "mapDidLoad") {
+    if (worldState.insideCatacombs.keySpellsObtained.length == 4) {
+      world.forEachEntities("magic_key", (magicKey) => {
+        magicKey.setInteractable(true);
+      });
+    }
+
     if (
       worldState.insideCatacombs.hasPledgeScroll &&
       !worldState.unlockedTransitions.includes("exit_to_courtyard")

--- a/levels/inside_perimeter/events.js
+++ b/levels/inside_perimeter/events.js
@@ -66,8 +66,10 @@ const LEVEL_STATE = {
               },
             },
             successActions: {
-              hasKey({ event }) {
-                event.target.setInteractable(false);
+              hasKey({ world }) {
+                world.forEachEntities("scroll_room_door", (door) => {
+                  door.setInteractable(false);
+                });
               },
             },
             failureActions: {
@@ -297,6 +299,13 @@ module.exports = async function (event, world) {
    * Handles returning level to last object state
    */
   if (event.name === "mapDidLoad") {
+    if (
+      worldState.insideCatacombs.hasPledgeScroll &&
+      !worldState.unlockedTransitions.includes("exit_to_courtyard")
+    ) {
+      worldState.unlockedTransitions.push("exit_to_courtyard");
+    }
+
     // destroy all previously destroyed objects
     world.destroyEntities(({ instance }) =>
       worldState.destroyedEntities.includes(instance.group || instance.key)
@@ -385,9 +394,7 @@ module.exports = async function (event, world) {
     }
   }
 
-  if (
-    worldState.insideCatacombs.hasPledgeScroll
-  ) {
+  if (worldState.insideCatacombs.hasPledgeScroll) {
     world.updateQuestStatus(
       world.__internals.level.levelName,
       world.__internals.level.levelProperties.questTitle,

--- a/levels/inside_perimeter/maps/catacombs.json
+++ b/levels/inside_perimeter/maps/catacombs.json
@@ -1957,6 +1957,11 @@
                          "value":"scroll_room_door"
                         }, 
                         {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"blue"
+                        }, 
+                        {
                          "name":"spell_type",
                          "type":"string",
                          "value":"unlock"
@@ -1988,6 +1993,11 @@
                          "name":"key",
                          "type":"string",
                          "value":"scroll_room_door"
+                        }, 
+                        {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"blue"
                         }, 
                         {
                          "name":"spell_type",
@@ -3109,7 +3119,7 @@
  "nextobjectid":422,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.8.0",
+ "tiledversion":"1.7.2",
  "tileheight":24,
  "tilesets":[
         {
@@ -3147,6 +3157,6 @@
         }],
  "tilewidth":24,
  "type":"map",
- "version":"1.8",
+ "version":"1.6",
  "width":60
 }

--- a/levels/inside_perimeter/maps/catacombs.json
+++ b/levels/inside_perimeter/maps/catacombs.json
@@ -1959,7 +1959,7 @@
                         {
                          "name":"spell_color",
                          "type":"string",
-                         "value":"blue"
+                         "value":"red"
                         }, 
                         {
                          "name":"spell_type",
@@ -1997,7 +1997,7 @@
                         {
                          "name":"spell_color",
                          "type":"string",
-                         "value":"blue"
+                         "value":"red"
                         }, 
                         {
                          "name":"spell_type",

--- a/levels/inside_perimeter/maps/catacombs.json
+++ b/levels/inside_perimeter/maps/catacombs.json
@@ -1791,7 +1791,7 @@
                         {
                          "name":"interactable",
                          "type":"bool",
-                         "value":true
+                         "value":false
                         }, 
                         {
                          "name":"item",

--- a/levels/inside_perimeter/maps/default.json
+++ b/levels/inside_perimeter/maps/default.json
@@ -247,6 +247,11 @@
                          "value":"bramble_block"
                         }, 
                         {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"red"
+                        }, 
+                        {
                          "name":"spell_type",
                          "type":"string",
                          "value":"disappear"
@@ -323,6 +328,11 @@
                          "value":"bramble_block"
                         }, 
                         {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"red"
+                        }, 
+                        {
                          "name":"spell_type",
                          "type":"string",
                          "value":"disappear"
@@ -359,6 +369,11 @@
                          "name":"key",
                          "type":"string",
                          "value":"bramble_block"
+                        }, 
+                        {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"red"
                         }, 
                         {
                          "name":"spell_type",
@@ -399,6 +414,11 @@
                          "value":"bramble_block"
                         }, 
                         {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"red"
+                        }, 
+                        {
                          "name":"spell_type",
                          "type":"string",
                          "value":"disappear"
@@ -435,6 +455,11 @@
                          "name":"key",
                          "type":"string",
                          "value":"bramble_block"
+                        }, 
+                        {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"red"
                         }, 
                         {
                          "name":"spell_type",
@@ -475,6 +500,11 @@
                          "value":"bramble_block"
                         }, 
                         {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"red"
+                        }, 
+                        {
                          "name":"spell_type",
                          "type":"string",
                          "value":"disappear"
@@ -511,6 +541,11 @@
                          "name":"key",
                          "type":"string",
                          "value":"bramble_block"
+                        }, 
+                        {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"red"
                         }, 
                         {
                          "name":"spell_type",
@@ -551,6 +586,11 @@
                          "value":"bramble_block"
                         }, 
                         {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"red"
+                        }, 
+                        {
                          "name":"spell_type",
                          "type":"string",
                          "value":"disappear"
@@ -587,6 +627,11 @@
                          "name":"key",
                          "type":"string",
                          "value":"bramble_block"
+                        }, 
+                        {
+                         "name":"spell_color",
+                         "type":"string",
+                         "value":"red"
                         }, 
                         {
                          "name":"spell_type",

--- a/levels/inside_perimeter/maps/default.json
+++ b/levels/inside_perimeter/maps/default.json
@@ -1054,6 +1054,16 @@
                  "name":"exit_to_courtyard",
                  "properties":[
                         {
+                         "name":"disabled",
+                         "type":"bool",
+                         "value":true
+                        }, 
+                        {
+                         "name":"key",
+                         "type":"string",
+                         "value":"exit_to_courtyard"
+                        }, 
+                        {
                          "name":"levelName",
                          "type":"string",
                          "value":"house_ceremony"
@@ -1067,11 +1077,6 @@
                          "name":"playerEntryPoint",
                          "type":"string",
                          "value":"player_entry1"
-                        }, 
-                        {
-                         "name":"requiresCompletedLevels",
-                         "type":"string",
-                         "value":"inside_perimeter"
                         }],
                  "rotation":0,
                  "type":"levelChange",
@@ -1814,7 +1819,7 @@
  "nextobjectid":264,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.8.0",
+ "tiledversion":"1.7.2",
  "tileheight":24,
  "tilesets":[
         {
@@ -1852,6 +1857,6 @@
         }],
  "tilewidth":24,
  "type":"map",
- "version":"1.8",
+ "version":"1.6",
  "width":71
 }

--- a/levels/lovelace_tower/events.js
+++ b/levels/lovelace_tower/events.js
@@ -80,12 +80,16 @@ module.exports = async function (event, world) {
     unlockPairs.forEach(([objectiveKey, hiddenDoorKey]) => {
       if (
         event.objective === objectiveKey &&
-        !worldState.insideLovelaceTower.hiddenEntities.includes(hiddenDoorKey)
+        !worldState.hiddenEntities.includes(hiddenDoorKey)
       ) {
-        worldState.insideLovelaceTower.hiddenEntities.push(hiddenDoorKey);
+        worldState.hiddenEntities.push(hiddenDoorKey);
       }
     });
   }
+
+  worldState.hiddenEntities.forEach((hiddenEntityKey) => {
+    world.hideEntities(hiddenEntityKey);
+  });
 
   if (event.name === "mapDidLoad") {
     if (

--- a/levels/lovelace_tower/events.js
+++ b/levels/lovelace_tower/events.js
@@ -23,7 +23,6 @@ const INITIAL_STATE = {
                 world.enableTransitionAreas(
                   ({ instance }) => instance.key === "exit_to_lovelace_library"
                 );
-                console.log("setting worldState");
                 worldState.insideLovelaceTower.usedSpellOnLibraryDoor = true;
               },
             },

--- a/levels/lovelace_tower/objectives/api-03-fetch/validator.js
+++ b/levels/lovelace_tower/objectives/api-03-fetch/validator.js
@@ -3,7 +3,8 @@ const { MAGIC_API_ENDPOINT } = require("../../../../scripts/config");
 module.exports = async function (helper) {
   try {
     const { magicalPhrase } = helper.validationFields;
-    const correctMagicPhrase = await fetch(MAGIC_API_ENDPOINT);
+    const response = await fetch(MAGIC_API_ENDPOINT);
+    const correctMagicPhrase = await response.text();
 
     if (!magicalPhrase) {
       return helper.fail(

--- a/levels/lovelace_tower/objectives/api-04-remote-and-local/validator.js
+++ b/levels/lovelace_tower/objectives/api-04-remote-and-local/validator.js
@@ -13,7 +13,7 @@ const assertTestCase = (testFunction, helper) => async (input, expected) => {
 
 function getBooksByPageCount(pageCountThreshold, books) {
   const filteredBooks = books.filter(
-    (book) => pageCountThreshold > book.metadata.pageCount
+    (book) => book.metadata.pageCount > pageCountThreshold
   );
   return filteredBooks;
 }
@@ -40,7 +40,8 @@ module.exports = async function (helper) {
 
     const test = assertTestCase(context.getFilteredAuthors, helper);
     const response = await fetch(DIVINATION_API_ENDPOINT);
-    const books = (await response.json()).data;
+    const books = await response.json();
+    console.log(books);
     await test(5, getAuthorNames(5, books));
     await test(100, getAuthorNames(100, books));
     await test(30, getAuthorNames(30, books));

--- a/scripts/handleSpells.js
+++ b/scripts/handleSpells.js
@@ -152,8 +152,10 @@ module.exports = async function handleSpells(event, world, worldState) {
       return;
     }
 
-    const targetSpellColor = event.target.spell_color.trim().toUpperCase();
-    await useWand(world, SPELL_TYPE[targetSpellColor] || SPELL_TYPE.RED);
+    const targetSpellColor = event.target.spell_color
+      ? event.target.spell_color.trim().toUpperCase()
+      : SPELL_TYPE.RED;
+    await useWand(world, SPELL_TYPE[targetSpellColor]);
     spells[event.target.spell_type](event);
   };
 

--- a/scripts/handleSpells.js
+++ b/scripts/handleSpells.js
@@ -153,9 +153,9 @@ module.exports = async function handleSpells(event, world, worldState) {
     }
 
     const targetSpellColor = event.target.spell_color
-      ? event.target.spell_color.trim().toUpperCase()
+      ? SPELL_TYPE[event.target.spell_color.trim().toUpperCase()]
       : SPELL_TYPE.RED;
-    await useWand(world, SPELL_TYPE[targetSpellColor]);
+    await useWand(world, targetSpellColor);
     spells[event.target.spell_type](event);
   };
 


### PR DESCRIPTION
-Updated spell color for catacomb pledge scroll doors to be red instead of blue
-Updated bramble such that the player's exclamation point is hidden while casting their spell. That way the animation isn't obscured
-Fixed bug where only one of the catacomb doors would have it's interactable state set to false
-Fixed bug where the transition to the courtyard map was enabled before the player had gotten their scroll from inside_perimeter
-Fixed bug where if a spellable object didn't have the "spell_color" property, an exception would be thrown
-Fixed bug where exception would be thrown right as you entered lovelace_tower/default map
-Fixed bug where lovelace_tower/default objective barriers wouldn't be removed after the player completed them
-Fixed bug in api-03-fetch objective's validator
-Fixed bug in api-04-remote-local validator
-Fixed bug where magic_key in catacomb was interactable despite being hidden
-Fixed bug where magic_key in catacomb could still be picked up when hidden and it's "interactable" property set to "false"
-Fixed bug where inside_perimeter bramble wouldn't invoke spell animation when interacted with after the player got the wand and spell
-Removed unneeded console log